### PR TITLE
Add support for building and serializing Radiotap values 

### DIFF
--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -1,0 +1,335 @@
+//! Radiotap struct builder.
+
+use crate::field::*;
+use crate::Radiotap;
+
+/// A convenience struct for building [`Radiotap`] values in code. It takes
+/// care of populating [`Radiotap::header`] based on which fields are set.
+///
+/// ```
+/// use radiotap::Radiotap;
+/// use radiotap::field::*;
+///
+/// let tap = Radiotap::build()
+///     .rate(Rate { value: 15.0 })
+///     .tsft(TSFT { value: 42 })
+///     .flags(Flags {
+///         wep: true,
+///         fragmentation: true,
+///         data_pad: true,
+///         ..Default::default()
+///     })
+///     .done();
+///
+/// assert_eq!(
+///     tap,
+///     Radiotap {
+///         header: Header {
+///             version: 0,
+///             size: 8,
+///             length: 18,
+///             present: vec![Kind::TSFT, Kind::Flags, Kind::Rate]
+///         },
+///         tsft: Some(TSFT { value: 42 }),
+///         flags: Some(Flags {
+///             wep: true,
+///             fragmentation: true,
+///             data_pad: true,
+///             ..Default::default()
+///         }),
+///         rate: Some(Rate { value: 15.0 }),
+///         ..Default::default()
+///     }
+/// );
+/// ```
+#[derive(Default)]
+pub struct RadiotapBuilder {
+    inner: Radiotap,
+}
+
+impl RadiotapBuilder {
+    pub(crate) fn new() -> Self {
+        RadiotapBuilder::default()
+    }
+
+    /// Returns a fully constructed [`Radiotap`] value.
+    pub fn done(mut self) -> Radiotap {
+        let header = &mut self.inner.header;
+
+        // Setters can be called in any order, but we need to process fields in the order in which
+        // they appear in the serialized format to correctly add up alignment/size values for each
+        // present field.
+        header.present.sort_by_key(|kind| kind.bit());
+        header.length = header.present.iter().fold(header.length, |length, kind| {
+            let size = kind.size();
+            let align = kind.align() as usize;
+
+            ((length + align - 1) & !(align - 1)) + size
+        });
+
+        self.inner
+    }
+}
+
+macro_rules! field {
+    ($name:ident, $type:ident) => {
+        #[doc = concat!("Sets the value of the [`Radiotap::", stringify!($name), "`] field.")]
+        pub fn $name(mut self, $name: $type) -> Self {
+            if !self.inner.header.present.contains(&Kind::$type) {
+                self.inner.header.present.push(Kind::$type);
+            }
+
+            self.inner.$name = Some($name);
+            self
+        }
+    };
+}
+impl RadiotapBuilder {
+    field!(tsft, TSFT);
+    field!(flags, Flags);
+    field!(rate, Rate);
+    field!(channel, Channel);
+    field!(fhss, FHSS);
+    field!(antenna_signal, AntennaSignal);
+    field!(antenna_noise, AntennaNoise);
+    field!(lock_quality, LockQuality);
+    field!(tx_attenuation, TxAttenuation);
+    field!(tx_attenuation_db, TxAttenuationDb);
+    field!(tx_power, TxPower);
+    field!(antenna, Antenna);
+    field!(antenna_signal_db, AntennaSignalDb);
+    field!(antenna_noise_db, AntennaNoiseDb);
+    field!(rx_flags, RxFlags);
+    field!(tx_flags, TxFlags);
+    field!(rts_retries, RTSRetries);
+    field!(data_retries, DataRetries);
+    field!(xchannel, XChannel);
+    field!(mcs, MCS);
+    field!(ampdu_status, AMPDUStatus);
+    field!(vht, VHT);
+    field!(timestamp, Timestamp);
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ext::*;
+
+    use super::*;
+
+    #[test]
+    fn set_none() {
+        let actual = Radiotap::build().done();
+        let expected = Radiotap::default();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn set_multiple() {
+        let actual = Radiotap::build()
+            .tsft(TSFT { value: 42 })
+            .timestamp(Timestamp {
+                timestamp: 700,
+                unit: TimeUnit::Microseconds,
+                position: SamplingPosition::StartMPDU,
+                accuracy: None,
+            })
+            .rate(Rate { value: 15.0 })
+            .flags(Flags {
+                wep: true,
+                fragmentation: true,
+                data_pad: true,
+                ..Default::default()
+            })
+            .channel(Channel {
+                freq: 2500,
+                flags: ChannelFlags {
+                    turbo: true,
+                    ..Default::default()
+                },
+            })
+            .done();
+        let expected = Radiotap {
+            header: Header {
+                version: 0,
+                length: 36, // header length + length of all fields + alignment of the timestamp field
+                size: 8,
+                present: vec![
+                    Kind::TSFT,
+                    Kind::Flags,
+                    Kind::Rate,
+                    Kind::Channel,
+                    Kind::Timestamp,
+                ],
+            },
+            tsft: Some(TSFT { value: 42 }),
+            flags: Some(Flags {
+                wep: true,
+                fragmentation: true,
+                data_pad: true,
+                ..Default::default()
+            }),
+            rate: Some(Rate { value: 15.0 }),
+            channel: Some(Channel {
+                freq: 2500,
+                flags: ChannelFlags {
+                    turbo: true,
+                    ..Default::default()
+                },
+            }),
+            timestamp: Some(Timestamp {
+                timestamp: 700,
+                unit: TimeUnit::Microseconds,
+                position: SamplingPosition::StartMPDU,
+                accuracy: None,
+            }),
+            ..Default::default()
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn set_twice() {
+        let actual = Radiotap::build()
+            .tsft(TSFT { value: 42 })
+            .tsft(TSFT { value: 84 })
+            .done();
+        let expected = Radiotap {
+            header: Header {
+                version: 0,
+                length: 16,
+                size: 8,
+                // only one entry in the present vector
+                present: vec![Kind::TSFT],
+            },
+            // last update wins
+            tsft: Some(TSFT { value: 84 }),
+            ..Default::default()
+        };
+        assert_eq!(actual, expected);
+    }
+
+    macro_rules! test_field {
+        ($name:ident, $kind:expr, $value:expr) => {
+            #[test]
+            fn $name() {
+                let actual = RadiotapBuilder::new().$name($value).done();
+                let expected = Radiotap {
+                    header: Header {
+                        version: 0,
+                        length: 8 + $kind.size(),
+                        size: 8,
+                        present: vec![$kind],
+                    },
+                    $name: Some($value),
+                    ..Default::default()
+                };
+                assert_eq!(actual, expected);
+            }
+        };
+    }
+
+    test_field!(tsft, Kind::TSFT, TSFT { value: 42 });
+    test_field!(
+        flags,
+        Kind::Flags,
+        Flags {
+            fragmentation: true,
+            data_pad: true,
+            ..Default::default()
+        }
+    );
+    test_field!(rate, Kind::Rate, Rate { value: 1.0 });
+    test_field!(
+        antenna_signal,
+        Kind::AntennaSignal,
+        AntennaSignal { value: -42 }
+    );
+    test_field!(
+        antenna_noise,
+        Kind::AntennaNoise,
+        AntennaNoise { value: 42 }
+    );
+    test_field!(lock_quality, Kind::LockQuality, LockQuality { value: 14 });
+    test_field!(
+        tx_attenuation,
+        Kind::TxAttenuation,
+        TxAttenuation { value: 0 }
+    );
+    test_field!(
+        tx_attenuation_db,
+        Kind::TxAttenuationDb,
+        TxAttenuationDb { value: 10 }
+    );
+    test_field!(tx_power, Kind::TxPower, TxPower { value: 17 });
+    test_field!(antenna, Kind::Antenna, Antenna { value: 1 });
+    test_field!(
+        antenna_signal_db,
+        Kind::AntennaSignalDb,
+        AntennaSignalDb { value: 13 }
+    );
+    test_field!(
+        antenna_noise_db,
+        Kind::AntennaNoiseDb,
+        AntennaNoiseDb { value: 12 }
+    );
+    test_field!(rx_flags, Kind::RxFlags, RxFlags { bad_plcp: true });
+    test_field!(
+        tx_flags,
+        Kind::TxFlags,
+        TxFlags {
+            no_ack: true,
+            rts: true,
+            ..Default::default()
+        }
+    );
+    test_field!(rts_retries, Kind::RTSRetries, RTSRetries { value: 44 });
+    test_field!(data_retries, Kind::DataRetries, DataRetries { value: 0 });
+    test_field!(
+        xchannel,
+        Kind::XChannel,
+        XChannel {
+            flags: XChannelFlags {
+                turbo: true,
+                ..Default::default()
+            },
+            freq: 2400,
+            channel: 42,
+            max_power: 10
+        }
+    );
+    test_field!(
+        mcs,
+        Kind::MCS,
+        MCS {
+            index: Some(42),
+            ..Default::default()
+        }
+    );
+    test_field!(
+        ampdu_status,
+        Kind::AMPDUStatus,
+        AMPDUStatus {
+            reference: 10,
+            zero_length: Some(true),
+            ..Default::default()
+        }
+    );
+    test_field!(
+        vht,
+        Kind::VHT,
+        VHT {
+            beamformed: Some(true),
+            ..Default::default()
+        }
+    );
+    test_field!(
+        timestamp,
+        Kind::Timestamp,
+        Timestamp {
+            timestamp: 600,
+            unit: TimeUnit::Milliseconds,
+            position: SamplingPosition::EndMPDU,
+            accuracy: None
+        }
+    );
+}

--- a/src/field/ext.rs
+++ b/src/field/ext.rs
@@ -167,7 +167,7 @@ pub fn vht_rate(index: u8, bw: Bandwidth, gi: GuardInterval, nss: u8) -> Result<
 }
 
 /// Flags describing the channel.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct ChannelFlags {
     /// Turbo channel.
     pub turbo: bool,
@@ -188,7 +188,7 @@ pub struct ChannelFlags {
 }
 
 /// Extended flags describing the channel.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct XChannelFlags {
     /// Turbo channel.
     pub turbo: bool,

--- a/src/field/ext.rs
+++ b/src/field/ext.rs
@@ -272,6 +272,44 @@ impl Bandwidth {
             sideband_index,
         })
     }
+
+    pub(crate) fn code(&self) -> Result<u8> {
+        let Bandwidth {
+            bandwidth,
+            sideband,
+            sideband_index,
+        } = self;
+
+        match (bandwidth, sideband, sideband_index) {
+            (20, None, None) => Ok(0),
+            (40, None, None) => Ok(1),
+            (40, Some(20), Some(0)) => Ok(2),
+            (40, Some(20), Some(1)) => Ok(3),
+            (80, None, None) => Ok(4),
+            (80, Some(40), Some(0)) => Ok(5),
+            (80, Some(40), Some(1)) => Ok(6),
+            (80, Some(20), Some(0)) => Ok(7),
+            (80, Some(20), Some(1)) => Ok(8),
+            (80, Some(20), Some(2)) => Ok(9),
+            (80, Some(20), Some(3)) => Ok(10),
+            (160, None, None) => Ok(11),
+            (160, Some(80), Some(0)) => Ok(12),
+            (160, Some(80), Some(1)) => Ok(13),
+            (160, Some(40), Some(0)) => Ok(14),
+            (160, Some(40), Some(1)) => Ok(15),
+            (160, Some(40), Some(2)) => Ok(16),
+            (160, Some(40), Some(3)) => Ok(17),
+            (160, Some(20), Some(0)) => Ok(18),
+            (160, Some(20), Some(1)) => Ok(19),
+            (160, Some(20), Some(2)) => Ok(20),
+            (160, Some(20), Some(3)) => Ok(21),
+            (160, Some(20), Some(4)) => Ok(22),
+            (160, Some(20), Some(5)) => Ok(23),
+            (160, Some(20), Some(6)) => Ok(24),
+            (160, Some(20), Some(7)) => Ok(25),
+            _ => Err(Error::InvalidFormat),
+        }
+    }
 }
 
 /// Represents a [VHT](../struct.VHT.html) user, the [VHT](../struct.VHT.html)
@@ -334,6 +372,14 @@ impl TimeUnit {
             }
         })
     }
+
+    pub(crate) fn code(&self) -> u8 {
+        match self {
+            TimeUnit::Milliseconds => 0,
+            TimeUnit::Microseconds => 1,
+            TimeUnit::Nanoseconds => 2,
+        }
+    }
 }
 
 /// The sampling position of the [Timestamp](../struct.Timestamp.html).
@@ -356,5 +402,15 @@ impl SamplingPosition {
             15 => SamplingPosition::Unknown,
             _ => return Err(Error::InvalidFormat),
         })
+    }
+
+    pub(crate) fn code(&self) -> u8 {
+        match self {
+            SamplingPosition::StartMPDU => 0,
+            SamplingPosition::StartPLCP => 1,
+            SamplingPosition::EndPPDU => 2,
+            SamplingPosition::EndMPDU => 3,
+            SamplingPosition::Unknown => 15,
+        }
     }
 }

--- a/src/field/mod.rs
+++ b/src/field/mod.rs
@@ -71,6 +71,36 @@ impl Kind {
         })
     }
 
+    /// Returns the bit number for the field.
+    pub fn bit(&self) -> u8 {
+        match self {
+            Kind::TSFT => 0,
+            Kind::Flags => 1,
+            Kind::Rate => 2,
+            Kind::Channel => 3,
+            Kind::FHSS => 4,
+            Kind::AntennaSignal => 5,
+            Kind::AntennaNoise => 6,
+            Kind::LockQuality => 7,
+            Kind::TxAttenuation => 8,
+            Kind::TxAttenuationDb => 9,
+            Kind::TxPower => 10,
+            Kind::Antenna => 11,
+            Kind::AntennaSignalDb => 12,
+            Kind::AntennaNoiseDb => 13,
+            Kind::RxFlags => 14,
+            Kind::TxFlags => 15,
+            Kind::RTSRetries => 16,
+            Kind::DataRetries => 17,
+            Kind::XChannel => 18,
+            Kind::MCS => 19,
+            Kind::AMPDUStatus => 20,
+            Kind::VHT => 21,
+            Kind::Timestamp => 22,
+            Kind::VendorNamespace(_) => 30,
+        }
+    }
+
     /// Returns the align value for the field.
     pub fn align(self) -> u64 {
         match self {
@@ -254,7 +284,7 @@ impl Field for TSFT {
 }
 
 /// Properties of transmitted and received frames.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Flags {
     /// The frame was sent/received during CFP.
     pub cfp: bool,
@@ -478,7 +508,7 @@ impl Field for Antenna {
 }
 
 /// Properties of received frames.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct RxFlags {
     pub bad_plcp: bool,
 }
@@ -493,7 +523,7 @@ impl Field for RxFlags {
 }
 
 /// Properties of transmitted frames.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct TxFlags {
     /// Transmission failed due to excessive retries.
     pub fail: bool,
@@ -869,5 +899,23 @@ impl Field for Timestamp {
             position,
             accuracy,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn supported_fields() {
+        for value in 0..u8::MAX {
+            match value {
+                0..=22 => {
+                    let kind = Kind::new(value).unwrap();
+                    assert_eq!(kind.bit(), value);
+                }
+                _ => assert!(matches!(Kind::new(value), Err(Error::UnsupportedField))),
+            }
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! # Usage
 //!
+//! ## Parsing Radiotap data
+//!
 //! The `Radiotap::from_bytes(&capture)` constructor will parse all present
 //! fields into a [Radiotap](struct.Radiotap.html) struct:
 //!
@@ -40,10 +42,50 @@
 //!     }
 //! }
 //! ```
+//!
+//! ## Building Radiotap packets
+//!
+//! It is also possible to build Radiotap packets programmatically (e.g. to be used
+//! for packet injection):
+//!
+//! ```
+//! use std::io::Cursor;
+//!
+//! use radiotap::Radiotap;
+//! use radiotap::field::*;
+//! use radiotap::field::ext::*;
+//!
+//! // Build a Radiotap value (the header will be populated automatically).
+//! let radiotap = Radiotap::build()
+//!     .tsft(TSFT { value: 42 })
+//!     .flags(Flags {
+//!         wep: true,
+//!         data_pad: true,
+//!         ..Default::default()
+//!     })
+//!     .rate(Rate { value: 4.5 })
+//!     .channel(Channel {
+//!         freq: 2400,
+//!         flags: ChannelFlags {
+//!             turbo: true,
+//!             ..Default::default()
+//!         },
+//!     })
+//!     .fhss(FHSS {
+//!         hopset: 1,
+//!         pattern: 2,
+//!     })
+//!     .done();
+//!
+//! // Serialize the value into a stream of bytes according to the Radiotap format rules.
+//! let mut buff = Cursor::new(Vec::new());
+//! radiotap.unparse(&mut buff).unwrap();
+//! ```
 
 pub mod builder;
 pub mod field;
 
+use std::io::Write;
 use std::{io::Cursor, result};
 
 use crate::builder::RadiotapBuilder;
@@ -279,11 +321,59 @@ impl Radiotap {
 
         Ok((radiotap, rest))
     }
+
+    /// Serializes a [Radiotap](struct.Radiotap.html) value into a stream of bytes.
+    /// Returns the size of the serialized Radiotap data in bytes or the encountered error.
+    pub fn unparse<W: Write>(&self, mut writer: W) -> Result<usize> {
+        let mut size = 0;
+
+        size += self.header.unparse(&mut writer)?;
+        for field_kind in self.header.present.iter() {
+            let align = field_kind.align() as usize;
+
+            let aligned_size = (size + align - 1) & !(align - 1);
+            while size < aligned_size {
+                size += writer.write(b"\x00")?;
+            }
+
+            let writer = &mut writer;
+            size += match field_kind {
+                Kind::TSFT => unparse_some(writer, self.tsft.as_ref())?,
+                Kind::Flags => unparse_some(writer, self.flags.as_ref())?,
+                Kind::Rate => unparse_some(writer, self.rate.as_ref())?,
+                Kind::Channel => unparse_some(writer, self.channel.as_ref())?,
+                Kind::FHSS => unparse_some(writer, self.fhss.as_ref())?,
+                Kind::AntennaSignal => unparse_some(writer, self.antenna_signal.as_ref())?,
+                Kind::AntennaNoise => unparse_some(writer, self.antenna_noise.as_ref())?,
+                Kind::LockQuality => unparse_some(writer, self.lock_quality.as_ref())?,
+                Kind::TxAttenuation => unparse_some(writer, self.tx_attenuation.as_ref())?,
+                Kind::TxAttenuationDb => unparse_some(writer, self.tx_attenuation_db.as_ref())?,
+                Kind::TxPower => unparse_some(writer, self.tx_power.as_ref())?,
+                Kind::Antenna => unparse_some(writer, self.antenna.as_ref())?,
+                Kind::AntennaSignalDb => unparse_some(writer, self.antenna_signal_db.as_ref())?,
+                Kind::AntennaNoiseDb => unparse_some(writer, self.antenna_noise_db.as_ref())?,
+                Kind::RxFlags => unparse_some(writer, self.rx_flags.as_ref())?,
+                Kind::TxFlags => unparse_some(writer, self.tx_flags.as_ref())?,
+                Kind::RTSRetries => unparse_some(writer, self.rts_retries.as_ref())?,
+                Kind::DataRetries => unparse_some(writer, self.data_retries.as_ref())?,
+                Kind::XChannel => unparse_some(writer, self.xchannel.as_ref())?,
+                Kind::MCS => unparse_some(writer, self.mcs.as_ref())?,
+                Kind::AMPDUStatus => unparse_some(writer, self.ampdu_status.as_ref())?,
+                Kind::VHT => unparse_some(writer, self.vht.as_ref())?,
+                Kind::Timestamp => unparse_some(writer, self.timestamp.as_ref())?,
+                _ => 0,
+            };
+        }
+
+        Ok(size)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use crate::ext::*;
 
     #[test]
     fn good_vendor() {
@@ -348,5 +438,114 @@ mod tests {
             Error::IncompleteError => {}
             e => panic!("Error not IncompleteError: {:?}", e),
         };
+    }
+
+    #[test]
+    fn unparse() {
+        let reference = Radiotap::build()
+            .tsft(TSFT { value: 42 })
+            .flags(Flags {
+                wep: true,
+                data_pad: true,
+                ..Default::default()
+            })
+            .rate(Rate { value: 4.5 })
+            .channel(Channel {
+                freq: 2400,
+                flags: ChannelFlags {
+                    turbo: true,
+                    ..Default::default()
+                },
+            })
+            .fhss(FHSS {
+                hopset: 1,
+                pattern: 2,
+            })
+            .antenna_signal(AntennaSignal { value: 1 })
+            .antenna_noise(AntennaNoise { value: 2 })
+            .lock_quality(LockQuality { value: 3 })
+            .tx_attenuation(TxAttenuation { value: 4 })
+            .tx_attenuation_db(TxAttenuationDb { value: 5 })
+            .tx_power(TxPower { value: 6 })
+            .antenna(Antenna { value: 7 })
+            .antenna_signal_db(AntennaSignalDb { value: 8 })
+            .antenna_noise_db(AntennaNoiseDb { value: 9 })
+            .rx_flags(RxFlags { bad_plcp: true })
+            .tx_flags(TxFlags {
+                fail: true,
+                cts: false,
+                rts: true,
+                ..Default::default()
+            })
+            .rts_retries(RTSRetries { value: 1 })
+            .data_retries(DataRetries { value: 2 })
+            .xchannel(XChannel {
+                flags: XChannelFlags {
+                    turbo: true,
+                    cck: false,
+                    ofdm: true,
+                    ghz2: true,
+                    gsm: true,
+                    sturbo: false,
+                    half: true,
+                    ..Default::default()
+                },
+                freq: 1234,
+                channel: 42,
+                max_power: 24,
+            })
+            .ampdu_status(AMPDUStatus {
+                reference: 17,
+                zero_length: Some(true),
+                last: Some(false),
+                delimiter_crc: Some(42),
+            })
+            .timestamp(Timestamp {
+                timestamp: 1234,
+                unit: TimeUnit::Nanoseconds,
+                position: SamplingPosition::StartMPDU,
+                accuracy: Some(1234),
+            })
+            .mcs(MCS {
+                bw: Some(Bandwidth::new(3).unwrap()),
+                index: Some(1),
+                gi: Some(GuardInterval::Short),
+                format: Some(HTFormat::Greenfield),
+                fec: Some(FEC::BCC),
+                stbc: Some(3),
+                ness: Some(2),
+                datarate: Some(30.0),
+            })
+            .vht(VHT {
+                stbc: Some(true),
+                txop_ps: Some(false),
+                gi: Some(GuardInterval::Long),
+                sgi_nsym_da: Some(false),
+                ldpc_extra: Some(true),
+                beamformed: Some(true),
+                bw: Some(Bandwidth::new(4).unwrap()),
+                group_id: Some(42),
+                partial_aid: Some(1234),
+                users: [
+                    None,
+                    None,
+                    Some(VHTUser {
+                        index: 1,
+                        fec: FEC::LDPC,
+                        nss: 4,
+                        nsts: 8,
+                        datarate: Some(234.0),
+                    }),
+                    None,
+                ],
+            })
+            .done();
+
+        // unparse() followed by parse() must return the original value.
+        let mut buff = Cursor::new(Vec::new());
+        let length = reference.unparse(&mut buff).unwrap();
+        let actual = Radiotap::parse(&buff.into_inner()).unwrap().0;
+        assert_eq!(actual.header.length, length);
+        assert_eq!(actual, reference);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,10 +41,12 @@
 //! }
 //! ```
 
+pub mod builder;
 pub mod field;
 
 use std::{io::Cursor, result};
 
+use crate::builder::RadiotapBuilder;
 use crate::field::*;
 
 /// All errors returned and used by the radiotap module.
@@ -223,6 +225,11 @@ pub struct Radiotap {
 }
 
 impl Radiotap {
+    /// Returns a [`RadiotapBuilder`] used for programmatically constructing a [`Radiotap`] value.
+    pub fn build() -> RadiotapBuilder {
+        RadiotapBuilder::new()
+    }
+
     /// Returns the parsed [Radiotap](struct.Radiotap.html) from an input byte
     /// array.
     pub fn from_bytes(input: &[u8]) -> Result<Radiotap> {


### PR DESCRIPTION
Hey, @rossmacarthur!

I was playing around with the code and I wonder what you think about the idea of adding support for:

1. Building `Radiotap` values programmatically
2. Serializing `Radiotap` values into the wire format

The former is sort of already possible by the nature of having all fields of the `Radiotap` struct declared as public, _but_ it's also annoying as the `Header` value needs to be updated accordingly afterwards. Also, some of the types do not currently implement `Default` which makes it tedious. A builder struct should make this straightforward.

And then we can implement serialization on top of that to support the use case of building Radiotap headers for packet injection.

Thank you!